### PR TITLE
Fix and expose sparsity

### DIFF
--- a/python/rebop/__init__.py
+++ b/python/rebop/__init__.py
@@ -9,19 +9,21 @@ __all__ = ("Gillespie", "__version__")
 og_run = Gillespie.run
 
 
-def run_xarray(
+def run_xarray(  # noqa: PLR0913 too many parameters in function definition
     self: Gillespie,
     init: dict[str, int],
     tmax: float,
     nb_steps: int,
     seed: int | None = None,
+    *,
+    sparse: bool = False,
 ) -> xr.Dataset:
     """Run the system until `tmax` with `nb_steps` steps.
 
     The initial configuration is specified in the dictionary `init`.
     Returns an xarray Dataset.
     """
-    times, result = og_run(self, init, tmax, nb_steps, seed)
+    times, result = og_run(self, init, tmax, nb_steps, seed, sparse=sparse)
     ds = xr.Dataset(
         data_vars={
             name: xr.DataArray(values, dims="time", coords={"time": times})

--- a/python/rebop/rebop.pyi
+++ b/python/rebop/rebop.pyi
@@ -30,6 +30,8 @@ class Gillespie:
         tmax: float,
         nb_steps: int,
         seed: int | None = None,
+        *,
+        sparse: bool = False,
     ) -> xarray.Dataset:
         """Run the system until `tmax` with `nb_steps` steps.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@
 //! ```rust
 //! use rebop::gillespie::{Gillespie, Rate};
 //!
-//! let mut sir = Gillespie::new([999, 1, 0]);
+//! let mut sir = Gillespie::new([999, 1, 0], false);
 //! //                           [  S, I, R]
 //! // S + I => 2 I with rate 1e-4
 //! sir.add_reaction(Rate::lma(1e-4, [1, 1, 0]), [-1, 1, 0]);
@@ -303,13 +303,14 @@ impl Gillespie {
     /// values at the given time points.  One can specify a random `seed` for reproducibility.
     /// If `nb_steps` is `0`, then returns all reactions, ending with the first that happens at
     /// or after `tmax`.
-    #[pyo3(signature = (init, tmax, nb_steps, seed=None))]
+    #[pyo3(signature = (init, tmax, nb_steps, seed=None, sparse=false))]
     fn run(
         &self,
         init: HashMap<String, usize>,
         tmax: f64,
         nb_steps: usize,
         seed: Option<u64>,
+        sparse: bool,
     ) -> PyResult<(Vec<f64>, HashMap<String, Vec<isize>>)> {
         let mut x0 = vec![0; self.species.len()];
         for (name, &value) in &init {
@@ -318,8 +319,8 @@ impl Gillespie {
             }
         }
         let mut g = match seed {
-            Some(seed) => gillespie::Gillespie::new_with_seed(x0, seed),
-            None => gillespie::Gillespie::new(x0),
+            Some(seed) => gillespie::Gillespie::new_with_seed(x0, sparse, seed),
+            None => gillespie::Gillespie::new(x0, sparse),
         };
 
         for (rate, reactants, products) in self.reactions.iter() {

--- a/tests/test_rebop.py
+++ b/tests/test_rebop.py
@@ -50,3 +50,12 @@ def test_all_reactions(seed: int) -> None:
     assert set(dds.S.to_numpy()) <= {-1, 0}
     assert set(dds.I.to_numpy()) <= {-1, 1}
     assert set(dds.R.to_numpy()) <= {0, 1}
+
+
+def test_dense_vs_sparse() -> None:
+    sir = sir_model()
+    init = {"S": 999, "I": 1}
+    kwargs = {"tmax": 250, "nb_steps": 250, "seed": 42}
+    ds_dense = sir.run(init, **kwargs, sparse=False)
+    ds_sparse = sir.run(init, **kwargs, sparse=True)
+    assert (ds_dense == ds_sparse).all()


### PR DESCRIPTION
*Note: this changes are built on top of the changes from #34, adding the type annotations for sparsity. I can remove that if you do not want to merge #34.*

Simulating a large system (~1000 reactions), I found necessary to use the sparse reactions, but they weren't exposed either in Python or Rust.

In Rust, I added a `sparse: bool` attribute to the `Gillespie` struct. Originally, I extended the signature of `pub fn add_reaction` with an `sparse: bool` parameter. But I think all reactions are either sparse or not and this way prevents mixing sparse and non sparse reactions by mistake.

Now, both `pub fn new` and `pub fn new_with_seed` take a `sparse: bool` argument. Alternatively, we could leave `new` as is, setting `sparse=false` in that case. In the future, you might want to change to a builder pattern:

```rust
GillespieBuilder::new()
        .initial(x0)
        .seed(42)        // optional
        .sparse(true)  // optional, default false
        .build();
```

From the Python side, I included a `sparse` keyword-only parameter with a default of `False`, so no changes are necessary to existing Python code.