### PR TITLE
feat: save subset of variables

### DIFF
--- a/python/rebop/__init__.py
+++ b/python/rebop/__init__.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import xarray as xr
 
 from .rebop import Gillespie, __version__  # type: ignore[attr-defined]
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 __all__ = ("Gillespie", "__version__")
 
@@ -17,13 +22,22 @@ def run_xarray(  # noqa: PLR0913 too many parameters in function definition
     seed: int | None = None,
     *,
     sparse: bool = False,
+    var_names: Sequence[str] | None = None,
 ) -> xr.Dataset:
     """Run the system until `tmax` with `nb_steps` steps.
 
     The initial configuration is specified in the dictionary `init`.
     Returns an xarray Dataset.
     """
-    times, result = og_run(self, init, tmax, nb_steps, seed, sparse=sparse)
+    times, result = og_run(
+        self,
+        init,
+        tmax,
+        nb_steps,
+        seed,
+        sparse=sparse,
+        var_names=var_names,
+    )
     ds = xr.Dataset(
         data_vars={
             name: xr.DataArray(values, dims="time", coords={"time": times})

--- a/python/rebop/rebop.pyi
+++ b/python/rebop/rebop.pyi
@@ -1,3 +1,5 @@
+from collections.abc import Sequence
+
 import xarray
 
 class Gillespie:
@@ -32,6 +34,7 @@ class Gillespie:
         seed: int | None = None,
         *,
         sparse: bool = False,
+        var_names: Sequence[str] | None = None,
     ) -> xarray.Dataset:
         """Run the system until `tmax` with `nb_steps` steps.
 

--- a/tests/test_rebop.py
+++ b/tests/test_rebop.py
@@ -59,3 +59,24 @@ def test_dense_vs_sparse() -> None:
     ds_dense = sir.run(init, **kwargs, sparse=False)
     ds_sparse = sir.run(init, **kwargs, sparse=True)
     assert (ds_dense == ds_sparse).all()
+
+
+@pytest.mark.parametrize("nb_steps", [0, 250])
+def test_var_names(nb_steps: int) -> None:
+    all_variables = {"S", "I", "R"}
+    subset_to_save = ["S", "I"]
+    remaining = all_variables.difference(subset_to_save)
+
+    sir = sir_model()
+    init = {"S": 999, "I": 1}
+    kwargs = {"tmax": 250, "nb_steps": nb_steps, "seed": 0}
+
+    ds_all = sir.run(init, **kwargs, var_names=None)
+    ds_subset = sir.run(init, **kwargs, var_names=subset_to_save)
+
+    for s in subset_to_save:
+        assert s in ds_subset
+    for s in remaining:
+        assert s not in ds_subset
+
+    assert ds_all[subset_to_save] == ds_subset

--- a/tests/test_rebop.py
+++ b/tests/test_rebop.py
@@ -55,9 +55,11 @@ def test_all_reactions(seed: int) -> None:
 def test_dense_vs_sparse() -> None:
     sir = sir_model()
     init = {"S": 999, "I": 1}
-    kwargs = {"tmax": 250, "nb_steps": 250, "seed": 42}
-    ds_dense = sir.run(init, **kwargs, sparse=False)
-    ds_sparse = sir.run(init, **kwargs, sparse=True)
+    tmax = 250
+    nb_steps = 250
+    seed = 42
+    ds_dense = sir.run(init, tmax=tmax, nb_steps=nb_steps, seed=seed, sparse=False)
+    ds_sparse = sir.run(init, tmax=tmax, nb_steps=nb_steps, seed=seed, sparse=True)
     assert (ds_dense == ds_sparse).all()
 
 
@@ -69,10 +71,13 @@ def test_var_names(nb_steps: int) -> None:
 
     sir = sir_model()
     init = {"S": 999, "I": 1}
-    kwargs = {"tmax": 250, "nb_steps": nb_steps, "seed": 0}
+    tmax = 250
+    seed = 0
 
-    ds_all = sir.run(init, **kwargs, var_names=None)
-    ds_subset = sir.run(init, **kwargs, var_names=subset_to_save)
+    ds_all = sir.run(init, tmax=tmax, nb_steps=nb_steps, seed=seed, var_names=None)
+    ds_subset = sir.run(
+        init, tmax=tmax, nb_steps=nb_steps, seed=seed, var_names=subset_to_save
+    )
 
     for s in subset_to_save:
         assert s in ds_subset


### PR DESCRIPTION
*Note: this changes are built on top of the changes from #34, adding the type annotations for sparsity. I can remove that if you do not want to merge #34.*

Allow to save a subset of the variables of the model, which can be relevant for large models, but I can understand if you prefer to keep the codebase simple.