### PR TITLE
Update version and release date in CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,4 +15,5 @@ repository-code: "https://github.com/Armavica/rebop"
 url: "https://armavica.github.io/rebop/"
 abstract: Fast stochastic simulator for chemical reaction networks
 license: MIT
-version: 0.8.3
+version: 0.9.1
+date-released: 2025-01-24


### PR DESCRIPTION
I just checked out your package and wanted to cite it. But when I used [jonaspleyer.github.io/crate2bib/](https://jonaspleyer.github.io/crate2bib/) to generate an entry I saw that the `CITATION.cff` and `crates.io` information was not matching. Thus the small update.